### PR TITLE
修复上午10点时小时显示为010的错误

### DIFF
--- a/Scripts/ChinaTelecom.js
+++ b/Scripts/ChinaTelecom.js
@@ -29,7 +29,7 @@ class Widget extends DmYY {
   iconColor = new Color('#827af1');
 
   format = (str) => {
-    return parseInt(str) > 10 ? str : `0${str}`;
+    return parseInt(str) >= 10 ? str : `0${str}`;
   };
 
   date = new Date();


### PR DESCRIPTION
当时间是上午10点进，如10点30分，更新时间会显示为 010:30。
修复显示问题。